### PR TITLE
adding "evaluate_on_test": true

### DIFF
--- a/allen_configs/multilang_dependency_parser.jsonnet
+++ b/allen_configs/multilang_dependency_parser.jsonnet
@@ -97,6 +97,7 @@
     "train_data_path": std.extVar("TRAIN_PATHNAME"),
     "validation_data_path": std.extVar("DEV_PATHNAME"),
     "test_data_path": std.extVar("TEST_PATHNAME"),
+    "evaluate_on_test": true,
     "trainer": {
         "cuda_device": 0,
         "num_epochs": 40,


### PR DESCRIPTION
SUMMARY: The current config does not output "test_UAS",  "test_LAS", "test_UEM", "test_LEM", "test_loss" into the standard output or to `metrics.json` even "test_data_path" is specified in the config file. Following [another example in the AllenNLP config](https://github.com/allenai/allennlp/blob/acfbb8c07caf8038a053a051acbc1996c6d016db/tutorials/getting_started/walk_through_allennlp/crf_tagger.json#L18), the solution is to simply add `"evaluate_on_test": true` to the config. 

TEST: Ran `allennlp train $CONFIG -s $OUTPUT_DIR`, where $CONFIG is borrowed and slightly modified from [the test config in AllenNLP](https://github.com/allenai/allennlp/blob/23efadd9a394d9d69e10e8539a7332665b118df0/allennlp/tests/fixtures/biaffine_dependency_parser_multilang/experiment.json). 

1. Example output of `metrics.json` **without** `"evaluate_on_test": true` (i.e., the current config)
```
{
  "best_epoch": 0,
  "peak_cpu_memory_MB": 203.681792,
  "training_duration": "0:00:00.155942",
  "training_start_epoch": 0,
  "training_epochs": 0,
  "epoch": 0,
  "training_UAS": 0.1038961038961039,
  "training_LAS": 0.012987012987012988,
  "training_UEM": 0.0,
  "training_LEM": 0.0,
  "training_loss": 5.463512897491455,
  "training_cpu_memory_MB": 199.585792,
  "validation_UAS": 0.175,
  "validation_LAS": 0.0,
  "validation_UEM": 0.0,
  "validation_LEM": 0.0,
  "validation_loss": 5.561254024505615,
  "best_validation_UAS": 0.175,
  "best_validation_LAS": 0.0,
  "best_validation_UEM": 0.0,
  "best_validation_LEM": 0.0,
  "best_validation_loss": 5.561254024505615
}
```

2. Example output of `metrics.json` **with** `"evaluate_on_test": true`
```
{
  "best_epoch": 0,
  "peak_cpu_memory_MB": 203.362304,
  "training_duration": "0:00:00.139146",
  "training_start_epoch": 0,
  "training_epochs": 0,
  "epoch": 0,
  "training_UAS": 0.1038961038961039,
  "training_LAS": 0.012987012987012988,
  "training_UEM": 0.0,
  "training_LEM": 0.0,
  "training_loss": 5.463512897491455,
  "training_cpu_memory_MB": 199.172096,
  "validation_UAS": 0.175,
  "validation_LAS": 0.0,
  "validation_UEM": 0.0,
  "validation_LEM": 0.0,
  "validation_loss": 5.561254024505615,
  "best_validation_UAS": 0.175,
  "best_validation_LAS": 0.0,
  "best_validation_UEM": 0.0,
  "best_validation_LEM": 0.0,
  "best_validation_loss": 5.561254024505615,
  "test_UAS": 0.175,
  "test_LAS": 0.0,
  "test_UEM": 0.0,
  "test_LEM": 0.0,
  "test_loss": 5.561254024505615
}
```